### PR TITLE
Fix build error (and runtime error) when running on Jellyfin 10.4.3

### DIFF
--- a/Jellyfin.Plugin.Reports/Api/Data/ReportBuilder.cs
+++ b/Jellyfin.Plugin.Reports/Api/Data/ReportBuilder.cs
@@ -33,7 +33,7 @@ namespace Jellyfin.Plugin.Reports.Api.Data
         /// <param name="items"> The items. </param>
         /// <param name="request"> The request. </param>
         /// <returns> The report result. </returns>
-        public ReportResult GetResult(BaseItem[] items, IReportsQuery request)
+        public ReportResult GetResult(IReadOnlyList<BaseItem> items, IReportsQuery request)
         {
             ReportIncludeItemTypes reportRowType = ReportHelper.GetRowType(request.IncludeItemTypes);
             ReportDisplayType displayType = ReportHelper.GetReportDisplayType(request.DisplayType);

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "jellyfin-plugin-reports"
 guid: "d4312cd9-5c90-4f38-82e8-51da566790e8"
 version: "4" # Please increment with each pull request
-jellyfin_version: "10.3.0" # The earliest binary-compatible version
+jellyfin_version: "10.4.3" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Reports"
 description: "Generate reports of your media library"


### PR DESCRIPTION
I had this plugin installed for a while now but it never worked. When I finally took some time to look what was wrong I found out it was due too a change in Jellyfin core, the plugin wouldn't even compile!