### PR TITLE
Bump Version

### DIFF
--- a/Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj
+++ b/Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>4.0.0</AssemblyVersion>
-    <FileVersion>4.0.0</FileVersion>
+    <AssemblyVersion>5.0.0</AssemblyVersion>
+    <FileVersion>5.0.0</FileVersion>
     <RootNamespace>Jellyfin.Plugin.Reports</RootNamespace>
   </PropertyGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-reports"
 guid: "d4312cd9-5c90-4f38-82e8-51da566790e8"
-version: "4" # Please increment with each pull request
+version: "5" # Please increment with each pull request
 jellyfin_version: "10.4.3" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Reports"


### PR DESCRIPTION
Bump version as it is working again for 10.4.3

For the nightly or 10.5.0 we might need another fix:
![image](https://user-images.githubusercontent.com/14938497/72796537-c68da800-3c3f-11ea-905a-80874d286d6a.png)
