### PR TITLE
Bump netstandard 2.0 -> 2.1

### DIFF
--- a/Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj
+++ b/Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>4.0.0</AssemblyVersion>
-    <FileVersion>4.0.0</FileVersion>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyVersion>5.0.0</AssemblyVersion>
+    <FileVersion>5.0.0</FileVersion>
     <RootNamespace>Jellyfin.Plugin.Reports</RootNamespace>
   </PropertyGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-reports"
 guid: "d4312cd9-5c90-4f38-82e8-51da566790e8"
-version: "5" # Please increment with each pull request
-jellyfin_version: "10.5.0" # The earliest binary-compatible version
+version: "5"
+jellyfin_version: "10.5.0"
 owner: "jellyfin"
 nicename: "Reports"
 description: "Generate reports of your media library"

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-reports"
 guid: "d4312cd9-5c90-4f38-82e8-51da566790e8"
-version: "4" # Please increment with each pull request
-jellyfin_version: "10.4.3" # The earliest binary-compatible version
+version: "5" # Please increment with each pull request
+jellyfin_version: "10.5.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Reports"
 description: "Generate reports of your media library"
@@ -12,4 +12,4 @@ artifacts:
   - "Jellyfin.Plugin.Reports.dll"
 build_type: "dotnet"
 dotnet_configuration: "Release"
-dotnet_framework: "netstandard2.0"
+dotnet_framework: "netstandard2.1"


### PR DESCRIPTION
Build fails with
```
Api/ReportsService.cs(111,94): error CS1503: Argument 1: cannot convert from 'string' to 'System.Guid' [/home/oddstr13/Projects/Jellyfin/Plugins/jellyfin-plugin-reports/Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj]
Api/ReportsService.cs(145,94): error CS1503: Argument 1: cannot convert from 'string' to 'System.Guid' [/home/oddstr13/Projects/Jellyfin/Plugins/jellyfin-plugin-reports/Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj]
```