### PR TITLE
Fix Overlay Button Accessibility 

### DIFF
--- a/Jellyfin.Plugin.Reports/Api/Data/ReportExport.cs
+++ b/Jellyfin.Plugin.Reports/Api/Data/ReportExport.cs
@@ -153,7 +153,7 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                 nextRow += rows.Count();
             }
 
-            using var workbook = new XLWorkbook(XLEventTracking.Disabled);
+            using var workbook = new XLWorkbook();
             IXLWorksheet worksheet = workbook.Worksheets.Add("ReportExport");
 
             // Add report rows

--- a/Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj
+++ b/Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.97.0" />
+    <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Jellyfin.Plugin.Reports/Web/reports.html
+++ b/Jellyfin.Plugin.Reports/Web/reports.html
@@ -59,8 +59,8 @@
         }
 
         .ui-panel-display-overlay {
-            z-index: 1001;
-            /* Fixed toolbars have z-index 1000 */
+            z-index: 1101;
+            /* Fixed toolbars have z-index 1100 */
         }
 
         .ui-panel-inner {
@@ -92,7 +92,7 @@
             left: 0;
             right: 0;
             height: 100%;
-            z-index: 1002;
+            z-index: 1102;
             display: none;
         }
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These reports can be exported to Excel and CSV formats.
 
 ## Build
 
-1. To build this plugin you will need [.Net 5.x](https://dotnet.microsoft.com/download/dotnet/5.0).
+1. To build this plugin you will need [.Net 8.x](https://dotnet.microsoft.com/download/dotnet/8.0).
 
 2. Build plugin with following command
   ```

--- a/build.yaml
+++ b/build.yaml
@@ -12,10 +12,13 @@ category: "General"
 artifacts:
   - "Jellyfin.Plugin.Reports.dll"
   - "ClosedXML.dll"
+  - "ClosedXML.Parser.dll"
   - "DocumentFormat.OpenXml.dll"
+  - "DocumentFormat.OpenXml.Framework.dll"
   - "ExcelNumberFormat.dll"
   - "System.IO.Packaging.dll"
   - "SixLabors.Fonts.dll"
+  - "RBush.dll"
 changelog: |-
   - put that thing in the correct place (#85) @crobibero
 


### PR DESCRIPTION
The main goal of this PR was to change the overlay z-index as the z-index of the main builtin Jellyfin toolbar also seems to have changed. This led to the top buttons in the report overlay becoming partially inaccessible. 

I also had to upgrade the `ClosedXML` nuget dependency as otherwise Jellyfin wouldn't load my new version anymore.  This upgrade was beneficial anyway, as ClosedXML had a vulnerability due to a transitive dependency, which was addressed in [release 0.104.2 ](https://github.com/ClosedXML/ClosedXML/releases/tag/0.104.2).



Dependency updates:

* `Jellyfin.Plugin.Reports/Jellyfin.Plugin.Reports.csproj`: Updated the `ClosedXML` package reference from version `0.97.0` to `0.104.2`.
* `build.yaml`: Added new DLLs required by the updated `ClosedXML` package.
* `Jellyfin.Plugin.Reports/Api/Data/ReportExport.cs`: Removed the `XLEventTracking.Disabled` parameter when creating a new `XLWorkbook` instance as this was a breaking change from the ClosedXML upgrade.

HTML updates:

* `Jellyfin.Plugin.Reports/Web/reports.html`: Increased the z-index values for `.ui-panel-display-overlay` and `.ui-panel-inner` to ensure proper layering over fixed toolbars.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31): Updated the .NET version requirement for building the plugin from `.Net 5.x` to `.Net 8.x`.

![image](https://github.com/user-attachments/assets/07c00d82-4421-4095-b936-f87c2103a5f4)
