### PR TITLE
Include file size in the report

### DIFF
--- a/Jellyfin.Plugin.Reports/Api/Common/HeaderActivitiesMetadata.cs
+++ b/Jellyfin.Plugin.Reports/Api/Common/HeaderActivitiesMetadata.cs
@@ -13,4 +13,29 @@ namespace Jellyfin.Plugin.Reports.Api.Common
         Item,
         User
     }
+
+    public static class ReportHelper
+    {
+        public static void GetOption(HeaderMetadata header, ReportOption option)
+        {
+            switch (header)
+            {
+                case HeaderMetadata.FileSize:
+                    option.Column = (i, r) =>
+                    {
+                        var sources = i.GetMediaSources(false);
+                        long totalSize = sources != null && sources.Any() ? sources.Sum(src => src.Size) : 0;
+                        return FormatFileSize(totalSize);
+                    };
+                    option.Header.HeaderFieldType = ReportFieldType.String;
+                    option.Header.SortField = "Size,SortName";
+                    break;
+            }
+        }
+
+        private static string FormatFileSize(long size)
+        {
+            return size.ToString();
+        }
+    }
 }

--- a/Jellyfin.Plugin.Reports/Api/Common/HeaderMetadata.cs
+++ b/Jellyfin.Plugin.Reports/Api/Common/HeaderMetadata.cs
@@ -53,6 +53,7 @@ namespace Jellyfin.Plugin.Reports.Api.Common
         Years,
         ParentalRatings,
         CommunityRatings,
+        FileSize,
 
         //Activity logs
         Overview,

--- a/Jellyfin.Plugin.Reports/Api/Common/ReportFieldType.cs
+++ b/Jellyfin.Plugin.Reports/Api/Common/ReportFieldType.cs
@@ -10,6 +10,7 @@ namespace Jellyfin.Plugin.Reports.Api.Common
         Int,
         Image,
         Object,
-        Minutes
+        Minutes,
+        FileSize
     }
 }

--- a/Jellyfin.Plugin.Reports/Api/Common/ReportHelper.cs
+++ b/Jellyfin.Plugin.Reports/Api/Common/ReportHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -122,6 +122,20 @@ namespace Jellyfin.Plugin.Reports.Api.Common
         public static string GetCoreLocalizedString(string phrase)
         {
             return phrase;
+        }
+
+        public static string FormatFileSize(long size)
+        {
+            if (size < 1024)
+                return $"{size} B";
+            else if (size < 1024 * 1024)
+                return $"{size / 1024.0:F2} KB";
+            else if (size < 1024 * 1024 * 1024)
+                return $"{size / (1024.0 * 1024):F2} MB";
+            else
+                return $"{size / (1024.0 * 1024 * 1024):F2} GB";
+            else
+                return $"{size / (1024.0 * 1024 * 1024 * 1024):F2} TB";
         }
     }
 }

--- a/Jellyfin.Plugin.Reports/Api/Data/ReportBuilder.cs
+++ b/Jellyfin.Plugin.Reports/Api/Data/ReportBuilder.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 
 using System.Collections.Generic;
 using System.Globalization;
@@ -94,7 +94,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.SeasonNumber,
                         HeaderMetadata.DateAdded,
                         HeaderMetadata.Year,
-                        HeaderMetadata.Genres
+                        HeaderMetadata.Genres,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.Series:
@@ -114,7 +115,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.CommunityRating,
                         HeaderMetadata.Runtime,
                         HeaderMetadata.Trailers,
-                        HeaderMetadata.Specials
+                        HeaderMetadata.Specials,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.MusicAlbum:
@@ -131,7 +133,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.ReleaseDate,
                         HeaderMetadata.Tracks,
                         HeaderMetadata.Year,
-                        HeaderMetadata.Genres
+                        HeaderMetadata.Genres,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.MusicArtist:
@@ -146,7 +149,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.Countries,
                         HeaderMetadata.DateAdded,
                         HeaderMetadata.Year,
-                        HeaderMetadata.Genres
+                        HeaderMetadata.Genres,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.Movie:
@@ -171,7 +175,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.Subtitles,
                         HeaderMetadata.Trailers,
                         HeaderMetadata.Specials,
-                        HeaderMetadata.Path
+                        HeaderMetadata.Path,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.Book:
@@ -188,7 +193,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.Year,
                         HeaderMetadata.Genres,
                         HeaderMetadata.ParentalRating,
-                        HeaderMetadata.CommunityRating
+                        HeaderMetadata.CommunityRating,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.BoxSet:
@@ -206,7 +212,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.Genres,
                         HeaderMetadata.ParentalRating,
                         HeaderMetadata.CommunityRating,
-                        HeaderMetadata.Trailers
+                        HeaderMetadata.Trailers,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.Audio:
@@ -229,7 +236,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.ParentalRating,
                         HeaderMetadata.CommunityRating,
                         HeaderMetadata.Runtime,
-                        HeaderMetadata.Audio
+                        HeaderMetadata.Audio,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.Episode:
@@ -257,7 +265,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.Subtitles,
                         HeaderMetadata.Trailers,
                         HeaderMetadata.Specials,
-                        HeaderMetadata.Path
+                        HeaderMetadata.Path,
+                        HeaderMetadata.FileSize
                     };
 
                 case ReportIncludeItemTypes.Video:
@@ -288,7 +297,8 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                         HeaderMetadata.Audio,
                         HeaderMetadata.Subtitles,
                         HeaderMetadata.Trailers,
-                        HeaderMetadata.Specials
+                        HeaderMetadata.Specials,
+                        HeaderMetadata.FileSize
                     };
 
             }
@@ -528,6 +538,11 @@ namespace Jellyfin.Plugin.Reports.Api.Data
                     option.Column = (i, r) => this.GetListAsString(i.Genres.ToList());
                     break;
 
+                case HeaderMetadata.FileSize:
+                    option.Column = (i, r) => i.GetMediaSources(false).FirstOrDefault()?.Size;
+                    option.Header.HeaderFieldType = ReportFieldType.Int;
+                    option.Header.SortField = "Size,SortName";
+                    break;
             }
 
             option.Header.Name = GetLocalizedHeader(internalHeader);


### PR DESCRIPTION
Add file size information to the report.

* Add `FileSize` entry to `HeaderMetadata` enum in `Jellyfin.Plugin.Reports/Api/Common/HeaderMetadata.cs`.
* Update `GetDefaultHeaderMetadata` method in `ReportBuilder` class to include `HeaderMetadata.FileSize`.
* Update `GetOption` method in `ReportBuilder` class to handle `HeaderMetadata.FileSize` and format file sizes appropriately.
* Add `FileSize` entry to `ReportFieldType` enum in `Jellyfin.Plugin.Reports/Api/Common/ReportFieldType.cs`.
* Add `FormatFileSize` method in `ReportHelper` class to format file sizes.
* Update `GetOption` method in `HeaderActivitiesMetadata` class to handle `HeaderMetadata.FileSize`.

