### PR TITLE
fix: require admin privileges to access reports API

### DIFF
--- a/Jellyfin.Plugin.Reports/Api/ReportsController.cs
+++ b/Jellyfin.Plugin.Reports/Api/ReportsController.cs
@@ -3,6 +3,7 @@ using System.Net.Mime;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Reports.Api.Common;
 using Jellyfin.Plugin.Reports.Api.Model;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Activity;
 using MediaBrowser.Model.Globalization;
@@ -14,7 +15,7 @@ namespace Jellyfin.Plugin.Reports.Api
 {
     [ApiController]
     [Route("[controller]")]
-    [Authorize]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [Produces(MediaTypeNames.Application.Json)]
     public class ReportsController : ControllerBase
     {


### PR DESCRIPTION
I have just reviewed the security of my Jellyfin server and figured out that the Reports plugin offers full access to its data to any user, not just administrators.

Therefore I updated the permissions for the reports API.