### PR TITLE
fix: export limiting to maximum 100 lines

### DIFF
--- a/Jellyfin.Plugin.Reports/Api/ReportsService.cs
+++ b/Jellyfin.Plugin.Reports/Api/ReportsService.cs
@@ -378,7 +378,7 @@ namespace Jellyfin.Plugin.Reports.Api
             var activityLogQuery = new ActivityLogQuery
             {
                 Skip = request.StartIndex,
-                Limit = request.HasQueryLimit ? request.Limit : null
+                Limit = request.Limit
             };
 
             var queryResult = await _activityManager.GetPagedResultAsync(activityLogQuery).ConfigureAwait(false);


### PR DESCRIPTION
Fix of only 100 lines export for activity logs 
see #70 